### PR TITLE
US or SI (metric) results

### DIFF
--- a/Sources/NationalWeatherService/services/calls/NWS+Forecast.swift
+++ b/Sources/NationalWeatherService/services/calls/NWS+Forecast.swift
@@ -10,10 +10,16 @@ import Foundation
 extension NationalWeatherService {
     public typealias ForecastHandler = (Result<Forecast, Error>) -> Void
 
+    /// Allow API customers to set the [UnitTemperature](https://developer.apple.com/documentation/foundation/unittemperature)
+    /// to get ["*US customary or SI (metric) units in textual output*"](https://www.weather.gov/documentation/services-web-api#/default/gridpoint_forecast)
+    public static var units: UnitTemperature = .celsius
+    
     fileprivate func loadForecast(at url: URL, then handler: @escaping ForecastHandler) {
         var components = URLComponents(url: url, resolvingAgainstBaseURL: false)!
+
+        let units: String = NationalWeatherService.units == .celsius ? "si" : "us"
         components.queryItems = [
-            URLQueryItem(name: "units", value: "si")
+            URLQueryItem(name: "units", value: units)
         ]
 
         self.load(at: components.url!, as: Forecast.self, then: handler)

--- a/Tests/NationalWeatherServiceTests/integration/GetForecastIntegrationTests.swift
+++ b/Tests/NationalWeatherServiceTests/integration/GetForecastIntegrationTests.swift
@@ -2,6 +2,7 @@ import XCTest
 @testable import NationalWeatherService
 
 final class GetForecastIntegrationTests: XCTestCase {
+    /// Get forecast without setting `NationalWeatherService.units`
     func testGetForecastForLocation() throws {
         let forecastExpectation = self.expectation(description: "get forecast expectation")
         nws.forecast(latitude: 47.6174, longitude: -122.2017) { result in
@@ -15,7 +16,44 @@ final class GetForecastIntegrationTests: XCTestCase {
 
         wait(for: [forecastExpectation], timeout: 5)
     }
+    
+    /// Get forecast by setting `NationalWeatherService.units` to `.fahrenheit`
+    func testGetForecastFahrenheit() throws {
+        let forecastExpectation = self.expectation(description: "get forecast expectation")
+        
+        NationalWeatherService.units = .fahrenheit
+        nws.forecast(latitude: 47.6174, longitude: -122.2017) { result in
+            XCTAssertSuccess(result)
 
+            let forecast = try! result.get()
+            print(forecast)
+            XCTAssertFalse(forecast.periods.isEmpty)
+
+            forecastExpectation.fulfill()
+        }
+
+        wait(for: [forecastExpectation], timeout: 5)
+    }
+    
+    /// Get forecast by setting `NationalWeatherService.units` to `.celsius`
+    func testGetForecastCelsius() throws {
+        let forecastExpectation = self.expectation(description: "get forecast expectation")
+        
+        NationalWeatherService.units = .celsius
+        nws.forecast(latitude: 47.6174, longitude: -122.2017) { result in
+            XCTAssertSuccess(result)
+
+            let forecast = try! result.get()
+            
+            print(forecast)
+            XCTAssertFalse(forecast.periods.isEmpty)
+
+            forecastExpectation.fulfill()
+        }
+
+        wait(for: [forecastExpectation], timeout: 5)
+    }
+    
     func testGetHourlyForecast() throws {
         let hourlyForecastExpectation = self.expectation(description: "get hourly forecast expectation")
         nws.hourlyForecast(latitude: 47.6174, longitude: -122.2017) { result in


### PR DESCRIPTION
Allow API customers to set the Swift Foundation `UnitTemperature` to get either US or SI (metric) results from the API

* Discussion on how to use US & SI units — https://github.com/weather-gov/api/discussions/422
* `pre-release` usage - https://github.com/roblabs/NationalWeatherService-Swift/releases/tag/0.4.2-beta

---

Example usage with this change:


## SI (metric) units

> *"A chance of rain showers. Mostly cloudy, with a high near 10. North northwest wind 17 to 24 km/h, with gusts as high as 33 km/h. Chance of precipitation is 40%. New rainfall amounts less than 0.5 cm possible."*

## US customary

> *"A chance of rain showers. Mostly cloudy, with a high near 50. North northwest wind 10 to 15 mph, with gusts as high as 21 mph. Chance of precipitation is 40%. New rainfall amounts less than a tenth of an inch possible."*

---

<img src="https://github.com/roblabs/NationalWeatherService-Swift/releases/download/0.4.2-beta/Share-the-World-Hidden.Valley.jpg" width=50%>


---

```swift
 let package = Package(
   // name: "SquareNumber",
   platforms: [ .iOS(.v10), .macOS(.v10_12) ], // The `NationalWeatherService-Swift`repo has these constraints, so be sure to match
   // products: [ ],
   dependencies: [
     .package(url: "https://github.com/roblabs/NationalWeatherService-Swift.git", .exactItem("0.4.2-beta"))
   ],
   targets: [
     .target(
       // name:...
       dependencies: [
         .product(name: "NationalWeatherService", package: "NationalWeatherService-Swift"),
       ]
     ),
   ]
 )
```